### PR TITLE
Fix: Resolver problema de autenticación 401 con tokens Sanctum

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -28,7 +28,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class, // Removido para SPA con tokens Bearer
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],


### PR DESCRIPTION
- Removido middleware EnsureFrontendRequestsAreStateful del grupo api
- Solucionado error "No access token available" en producción
- Permite autenticación correcta con tokens Bearer para SPA